### PR TITLE
Player last_online timestamp to use MySQL DATETIME

### DIFF
--- a/server/sv_player_session.lua
+++ b/server/sv_player_session.lua
@@ -257,7 +257,7 @@ function(SaveDatas)
 				SaveDatas._Gang, 
 				SaveDatas._GangRank,
 				SaveDatas._Inventory,
-				os.time(),
+				dateLisible,
 				SourceSteamID,
 				SaveDatas._Charid
 			})


### PR DESCRIPTION
Fix player last_online timestamp to use MySQL DATETIME format

- Changed the value stored in the last_online column from a Unix timestamp to a MySQL-compatible datetime string using os.date.

- Updated sv_player_session.lua to use the formatted dateLisible variable for consistency.

- This resolves MySQL errors related to incorrect datetime values when saving player data.